### PR TITLE
Parameterize check extensions

### DIFF
--- a/lib/sensu/settings/validators/check.rb
+++ b/lib/sensu/settings/validators/check.rb
@@ -61,8 +61,12 @@ module Sensu
             invalid(check, "check name must be a string")
           must_match_regex(/^[\w\.-]+$/, check[:name]) ||
             invalid(check, "check name cannot contain spaces or special characters")
+          must_be_a_string_if_set(check[:command]) ||
+            invalid(check, "check command must be a string")
+          must_be_a_string_if_set(check[:extension]) ||
+            invalid(check, "check extension must be a string")
           (must_be_a_string(check[:command]) ^ must_be_a_string(check[:extension])) ||
-            invalid(check, "one of check command or check extension must be a string")
+            invalid(check, "one of check command or check extension must be set and a string, but not both")
           must_be_a_numeric_if_set(check[:timeout]) ||
             invalid(check, "check timeout must be numeric")
           must_be_a_string_if_set(check[:source]) ||

--- a/lib/sensu/settings/validators/check.rb
+++ b/lib/sensu/settings/validators/check.rb
@@ -66,7 +66,7 @@ module Sensu
           must_be_a_string_if_set(check[:extension]) ||
             invalid(check, "check extension must be a string")
           (!check[:command].nil? ^ !check[:extension].nil?) ||
-            invalid(check, "one of check command or check extension must be set, but not both")
+            invalid(check, "either check command or extension must be set")
           must_be_a_numeric_if_set(check[:timeout]) ||
             invalid(check, "check timeout must be numeric")
           must_be_a_string_if_set(check[:source]) ||

--- a/lib/sensu/settings/validators/check.rb
+++ b/lib/sensu/settings/validators/check.rb
@@ -65,8 +65,8 @@ module Sensu
             invalid(check, "check command must be a string")
           must_be_a_string_if_set(check[:extension]) ||
             invalid(check, "check extension must be a string")
-          (must_be_a_string(check[:command]) ^ must_be_a_string(check[:extension])) ||
-            invalid(check, "one of check command or check extension must be set and a string, but not both")
+          (!check[:command].nil? ^ !check[:extension].nil?) ||
+            invalid(check, "one of check command or check extension must be set, but not both")
           must_be_a_numeric_if_set(check[:timeout]) ||
             invalid(check, "check timeout must be numeric")
           must_be_a_string_if_set(check[:source]) ||

--- a/lib/sensu/settings/validators/check.rb
+++ b/lib/sensu/settings/validators/check.rb
@@ -61,8 +61,8 @@ module Sensu
             invalid(check, "check name must be a string")
           must_match_regex(/^[\w\.-]+$/, check[:name]) ||
             invalid(check, "check name cannot contain spaces or special characters")
-          must_be_a_string(check[:command]) ||
-            invalid(check, "check command must be a string")
+          (must_be_a_string(check[:command]) ^ must_be_a_string(check[:extension])) ||
+            invalid(check, "one of check command or check extension must be a string")
           must_be_a_numeric_if_set(check[:timeout]) ||
             invalid(check, "check timeout must be numeric")
           must_be_a_string_if_set(check[:source]) ||

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -58,7 +58,7 @@ describe "Sensu::Settings::Validator" do
       failure[:message]
     end
     expect(reasons).to include("check name cannot contain spaces or special characters")
-    expect(reasons).to include("one of check command or check extension must be set, but not both")
+    expect(reasons).to include("either check command or extension must be set")
     expect(reasons).to include("check interval must be an integer")
     expect(reasons).to include("check subscribers must be an array")
     expect(reasons.size).to eq(5)

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -57,9 +57,8 @@ describe "Sensu::Settings::Validator" do
     reasons = @validator.failures.map do |failure|
       failure[:message]
     end
-    expect(reasons).to include("check name must be a string")
     expect(reasons).to include("check name cannot contain spaces or special characters")
-    expect(reasons).to include("one of check command or check extension must be a string")
+    expect(reasons).to include("one of check command or check extension must be set, but not both")
     expect(reasons).to include("check interval must be an integer")
     expect(reasons).to include("check subscribers must be an array")
     expect(reasons.size).to eq(5)

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -59,7 +59,7 @@ describe "Sensu::Settings::Validator" do
     end
     expect(reasons).to include("check name must be a string")
     expect(reasons).to include("check name cannot contain spaces or special characters")
-    expect(reasons).to include("check command must be a string")
+    expect(reasons).to include("one of check command or check extension must be a string")
     expect(reasons).to include("check interval must be an integer")
     expect(reasons).to include("check subscribers must be an array")
     expect(reasons.size).to eq(5)

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -147,6 +147,15 @@ describe "Sensu::Settings::Validator" do
     check[:source] = "switch-%42%"
     @validator.validate_check(check)
     expect(@validator.reset).to eq(0)
+    check[:extension] = 'foo'
+    @validator.validate_check(check)
+    expect(@validator.reset).to eq(1)
+    check.delete(:command)
+    @validator.validate_check(check)
+    expect(@validator.reset).to eq(0)
+    check[:extension] = true
+    @validator.validate_check(check)
+    expect(@validator.reset).to eq(1)
   end
 
   it "can validate check subdue" do


### PR DESCRIPTION
This updates the check validator to that require one of check[:command] or check[:extension] is a string. Tests have been updated to reflect this constraint. This PR is required by https://github.com/sensu/sensu/pull/889