### PR TITLE
Add `SENSU_CLIENT_NAME` to loaded env_vars

### DIFF
--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -59,8 +59,13 @@ module Sensu
       end
 
       # Load settings from the environment.
-      # Loads: RABBITMQ_URL, REDIS_URL, REDISTOGO_URL, API_PORT, PORT
+      # Loads: SENSU_CLIENT_NAME, RABBITMQ_URL, REDIS_URL, REDISTOGO_URL, API_PORT, PORT
       def load_env
+        if ENV["SENSU_CLIENT_NAME"]
+          @settings[:client][:name] = ENV["SENSU_CLIENT_NAME"]
+          warning("using sensu client name environment variable",
+                  :name => @settings[:client][:name])
+        end
         if ENV["RABBITMQ_URL"]
           @settings[:rabbitmq] = ENV["RABBITMQ_URL"]
           warning("using rabbitmq url environment variable", :rabbitmq => @settings[:rabbitmq])


### PR DESCRIPTION
There are some situations, specifically docker, where you really want to
dynamically assign a name, and you don't want to do it with a full
provisioner run.