### PR TITLE
Costumize where sensu_loaded_tempfile is persisted

### DIFF
--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -333,7 +333,7 @@ module Sensu
       # @return [String] tempfile path.
       def create_loaded_tempfile!
         dir = ENV["SENSU_LOADED_TEMPFILE_DIR"] || Dir.tmpdir
-				file_name = "sensu_#{sensu_service_name}_loaded_files"
+        file_name = "sensu_#{sensu_service_name}_loaded_files"
         path = File.join(dir, file_name)
         File.open(path, "w") do |file|
           file.write(@loaded_files.join(":"))

--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -332,8 +332,9 @@ module Sensu
       #
       # @return [String] tempfile path.
       def create_loaded_tempfile!
-        file_name = "sensu_#{sensu_service_name}_loaded_files"
-        path = File.join(Dir.tmpdir, file_name)
+        dir = ENV["SENSU_LOADED_TEMPFILE_DIR"] || Dir.tmpdir
+				file_name = "sensu_#{sensu_service_name}_loaded_files"
+        path = File.join(dir, file_name)
         File.open(path, "w") do |file|
           file.write(@loaded_files.join(":"))
         end


### PR DESCRIPTION
We have sensu deployed on Amazon Web Services and we use a default ami based on amazon linux. We have noticed that some handlers that reads the environment variable `ENV["SENSU_LOADED_TEMPFILE"]` crashes because the file does not longer exist.:

```
{"timestamp":"2015-12-03T08:06:10.412396+0000","level":"info","message":"handler output","handler":{"type":"pipe","command":"victorops.rb","name":"victorops"},"output":["/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/utils.rb:7:in `read': No such file or directory - /tmp/sensu_server_loaded_files (Errno::ENOENT)\n","\tfrom /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/utils.rb:7:in `config_files'\n","\tfrom /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/utils.rb:20:in `settings'\n","\tfrom /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-handler.rb:104:in `filter_repeated'\n","\tfrom /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-handler.rb:30:in `filter'\n","\tfrom /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.2.0/lib/sensu-handler.rb:54:in `block in <class:Handler>'\n"]}
```
After digging into the issue, we found that some RHEL / Debian distributions run a task ( On RHEL6  ` /etc/cron.daily/tmpwatch`; On RHEL7 `/usr/lib/tmpfiles.d/tmp.conf`; On Debian `/etc/default/rcS`) to cleanup the tmp files. If the tmp file doesn't exist the process crashes [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/lib/sensu-plugin/utils.rb#L7).

This could be fixed on the system layer, but it would be nice to have the possibility to select where sensu persist this file. With this fix you only need to set up the environment variable at `/etc/default/sensu`.

Tests are missing, just waiting for your feedback.