### PR TITLE
Consistent strong validation, files and definitions

### DIFF
--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -24,8 +24,9 @@ module Sensu
             @loader.load_directory(directory)
           end
         end
-        @loader.validate
-        @loader.set_env!
+        if @loader.validate.empty?
+          @loader.set_env!
+        end
         @loader
       rescue Loader::Error
         @loader

--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -24,7 +24,10 @@ module Sensu
             @loader.load_directory(directory)
           end
         end
+        @loader.validate
         @loader.set_env!
+        @loader
+      rescue Loader::Error
         @loader
       end
 

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -106,26 +106,21 @@ describe "Sensu::Settings::Loader" do
   end
 
   it "can attempt to load settings from a nonexistent file" do
-    @loader.load_file("/tmp/bananaphone")
-    warnings = @loader.warnings
-    expect(warnings.size).to eq(2)
-    messages = warnings.map do |warning|
-      warning[:message]
-    end
-    expect(messages).to include("config file does not exist or is not readable")
-    expect(messages).to include("ignoring config file")
+    expect {
+      @loader.load_file("/tmp/bananaphone")
+    }.to raise_error(Sensu::Settings::Loader::Error)
+    expect(@loader.errors.length).to eq(1)
+    error = @loader.errors.first
+    expect(error[:message]).to include("config file does not exist or is not readable")
   end
 
   it "can attempt to load settings from a file with invalid JSON" do
-    @loader.load_file(File.join(@assets_dir, "invalid.json"))
-    warnings = @loader.warnings
-    expect(warnings.size).to eq(3)
-    messages = warnings.map do |warning|
-      warning[:message]
-    end
-    expect(messages).to include("loading config file")
-    expect(messages).to include("config file must be valid json")
-    expect(messages).to include("ignoring config file")
+    expect {
+      @loader.load_file(File.join(@assets_dir, "invalid.json"))
+    }.to raise_error(Sensu::Settings::Loader::Error)
+    expect(@loader.errors.length).to eq(1)
+    error = @loader.errors.first
+    expect(error[:message]).to include("config file must be valid json")
   end
 
   it "can load settings from a utf-8 encoded file with a bom" do

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -49,4 +49,11 @@ describe "Sensu::Settings" do
     expect(settings[:checks][:merger][:command]).to eq("echo -n merger")
     expect(settings[:checks][:app_http_endpoint][:command]).to eq("check-http.rb -u https://localhost/ping -q pong")
   end
+
+  it "can catch load errors" do
+    settings = Sensu::Settings.load(:config_file => "/tmp/bananaphone")
+    expect(settings.errors.length).to eq(1)
+    error = settings.errors.first
+    expect(error[:message]).to include("config file does not exist or is not readable")
+  end
 end


### PR DESCRIPTION
This pull request makes validation behaviour consistent between file loading errors and definition validation failures. A file loading error will immediately record an error message (with context) and then raise an exception to trigger a return. Sensu can inspect `errors`.

This change enables/supports https://github.com/sensu/sensu/issues/1244