### PR TITLE
Default and validate Sensu process settings

### DIFF
--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -34,6 +34,11 @@ module Sensu
       # @return [Hash] settings.
       def default_settings
         default = {
+          :sensu => {
+            :spawn => {
+              :limit => 12
+            }
+          },
           :transport => {
             :name => "rabbitmq",
             :reconnect_on_error => true

--- a/lib/sensu/settings/validator.rb
+++ b/lib/sensu/settings/validator.rb
@@ -22,8 +22,9 @@ module Sensu
       # @param service [String] sensu service to validate for.
       # @return [Array] validation failures.
       def run(settings, service=nil)
-        validate_categories(settings)
+        validate_sensu(settings[:sensu])
         validate_transport(settings[:transport])
+        validate_categories(settings)
         case service
         when "client"
           validate_client(settings[:client])

--- a/lib/sensu/settings/validators.rb
+++ b/lib/sensu/settings/validators.rb
@@ -1,3 +1,4 @@
+require "sensu/settings/validators/sensu"
 require "sensu/settings/validators/subdue"
 require "sensu/settings/validators/check"
 require "sensu/settings/validators/filter"
@@ -10,6 +11,7 @@ require "sensu/settings/validators/transport"
 module Sensu
   module Settings
     module Validators
+      include Sensu
       include Subdue
       include Check
       include Filter

--- a/lib/sensu/settings/validators.rb
+++ b/lib/sensu/settings/validators.rb
@@ -1,4 +1,5 @@
 require "sensu/settings/validators/sensu"
+require "sensu/settings/validators/transport"
 require "sensu/settings/validators/subdue"
 require "sensu/settings/validators/check"
 require "sensu/settings/validators/filter"
@@ -6,12 +7,12 @@ require "sensu/settings/validators/mutator"
 require "sensu/settings/validators/handler"
 require "sensu/settings/validators/client"
 require "sensu/settings/validators/api"
-require "sensu/settings/validators/transport"
 
 module Sensu
   module Settings
     module Validators
       include Sensu
+      include Transport
       include Subdue
       include Check
       include Filter
@@ -19,7 +20,6 @@ module Sensu
       include Handler
       include Client
       include API
-      include Transport
     end
   end
 end

--- a/lib/sensu/settings/validators/sensu.rb
+++ b/lib/sensu/settings/validators/sensu.rb
@@ -1,0 +1,37 @@
+module Sensu
+  module Settings
+    module Validators
+      module Sensu
+        # Validate Sensu spawn.
+        # Validates: limit
+        #
+        # @param sensu [Hash] sensu definition.
+        def validate_sensu_spawn(sensu)
+          spawn = sensu[:spawn]
+          if is_a_hash?(spawn)
+            if is_an_integer?(spawn[:limit])
+              spawn[:limit] > 0 ||
+                invalid(sensu, "sensu spawn limit must be greater than 0")
+            else
+              invalid(sensu, "sensu spawn limit must be an integer")
+            end
+          else
+            invalid(sensu, "sensu spawn must be a hash")
+          end
+        end
+
+        # Validate a Sensu definition.
+        # Validates: spawn
+        #
+        # @param sensu [Hash] sensu definition.
+        def validate_sensu(sensu)
+          if is_a_hash?(sensu)
+            validate_sensu_spawn(sensu)
+          else
+            invalid(sensu, "sensu must be a hash")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -21,7 +21,46 @@ describe "Sensu::Settings::Validator" do
     expect(reasons).to include("filters must be a hash")
     expect(reasons).to include("mutators must be a hash")
     expect(reasons).to include("handlers must be a hash")
-    expect(reasons.size).to eq(5)
+    expect(reasons.size).to eq(6)
+  end
+
+  it "can validate a sensu definition" do
+    sensu = nil
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu = 1
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu = {}
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:spawn] = 1
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:spawn] = {}
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:spawn][:limit] = "1"
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:spawn][:limit] = 20
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(0)
+  end
+
+  it "can run, validating sensu" do
+    settings = {
+      :sensu => {
+        :spawn => {
+          :limit => "20"
+        }
+      }
+    }
+    @validator.run(settings)
+    expect(@validator.reset).to eq(6)
+    settings[:sensu][:spawn][:limit] = 20
+    @validator.run(settings)
+    expect(@validator.reset).to eq(5)
   end
 
   it "can validate a transport definition" do
@@ -52,10 +91,10 @@ describe "Sensu::Settings::Validator" do
       }
     }
     @validator.run(settings)
-    expect(@validator.reset).to eq(5)
+    expect(@validator.reset).to eq(6)
     settings[:transport][:name] = "rabbitmq"
     @validator.run(settings)
-    expect(@validator.reset).to eq(4)
+    expect(@validator.reset).to eq(5)
   end
 
   it "can validate an empty check definition" do
@@ -258,10 +297,10 @@ describe "Sensu::Settings::Validator" do
       }
     }
     @validator.run(settings)
-    expect(@validator.reset).to eq(5)
+    expect(@validator.reset).to eq(6)
     settings[:checks][:foo][:interval] = 1
     @validator.run(settings)
-    expect(@validator.reset).to eq(4)
+    expect(@validator.reset).to eq(5)
   end
 
   it "can validate a filter definition" do
@@ -671,10 +710,10 @@ describe "Sensu::Settings::Validator" do
       }
     }
     @validator.run(settings, "client")
-    expect(@validator.reset).to eq(6)
+    expect(@validator.reset).to eq(7)
     settings[:client][:subscriptions] = ["bar"]
     @validator.run(settings, "client")
-    expect(@validator.reset).to eq(5)
+    expect(@validator.reset).to eq(6)
   end
 
   it "can validate an api definition" do
@@ -720,9 +759,9 @@ describe "Sensu::Settings::Validator" do
       }
     }
     @validator.run(settings, "api")
-    expect(@validator.reset).to eq(6)
+    expect(@validator.reset).to eq(7)
     settings[:api][:port] = 4567
     @validator.run(settings, "api")
-    expect(@validator.reset).to eq(5)
+    expect(@validator.reset).to eq(6)
   end
 end


### PR DESCRIPTION
This pull request adds default Sensu process settings, e.g. spawn limit. The Sensu process settings are validated.

![tumblr_n6wggo6ioe1shxaddo1_500](https://cloud.githubusercontent.com/assets/149630/15307647/f5394a0e-1b89-11e6-9fc7-9b7d6d63892d.gif)
