### PR TITLE
Support missing legacy config.json

### DIFF
--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -14,7 +14,7 @@ module Sensu
         @loader = Loader.new
         @loader.load_env
         if options[:config_file]
-          @loader.load_file(options[:config_file])
+          @loader.load_file(options[:config_file], false)
         end
         if options[:config_dir]
           @loader.load_directory(options[:config_dir])

--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -99,7 +99,9 @@ module Sensu
       # Load settings from a JSON file.
       #
       # @param [String] file path.
-      def load_file(file)
+      # @param must_exist [TrueClass, FalseClass] if the file must
+      #   exist and is readable.
+      def load_file(file, must_exist=true)
         if File.file?(file) && File.readable?(file)
           begin
             warning("loading config file", :file => file)
@@ -122,8 +124,11 @@ module Sensu
               :error => error.to_s
             })
           end
-        else
+        elsif must_exist
           load_error("config file does not exist or is not readable", :file => file)
+        else
+          warning("config file does not exist or is not readable", :file => file)
+          warning("ignoring config file", :file => file)
         end
       end
 

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -114,6 +114,14 @@ describe "Sensu::Settings::Loader" do
     expect(error[:message]).to include("config file does not exist or is not readable")
   end
 
+  it "can attempt to load settings from a nonexistent file and ignore it" do
+    @loader.load_file("/tmp/bananaphone", false)
+    expect(@loader.errors.length).to eq(0)
+    expect(@loader.warnings.length).to eq(2)
+    warning = @loader.warnings.last
+    expect(warning[:message]).to include("ignoring config file")
+  end
+
   it "can attempt to load settings from a file with invalid JSON" do
     expect {
       @loader.load_file(File.join(@assets_dir, "invalid.json"))

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -51,9 +51,17 @@ describe "Sensu::Settings" do
   end
 
   it "can catch load errors" do
-    settings = Sensu::Settings.load(:config_file => "/tmp/bananaphone")
+    settings = Sensu::Settings.load(:config_file => File.join(@assets_dir, "invalid.json"))
     expect(settings.errors.length).to eq(1)
     error = settings.errors.first
-    expect(error[:message]).to include("config file does not exist or is not readable")
+    expect(error[:message]).to include("config file must be valid json")
+  end
+
+  it "can handle a nonexistent config.json" do
+    settings = Sensu::Settings.load(:config_file => "/tmp/bananaphone")
+    expect(settings.errors.length).to eq(0)
+    expect(settings.warnings.length).to eq(2)
+    warning = settings.warnings.last
+    expect(warning[:message]).to include("ignoring config file")
   end
 end


### PR DESCRIPTION
This PR fixes https://github.com/sensu/sensu/issues/1312

Sensu service management (i.e sysvinit script) currently configures a default `config.json` path, which some users do not actually use.
