### PR TITLE
add auto-detection of client name and address

### DIFF
--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -279,10 +279,13 @@ module Sensu
       #
       # The client subscriptions defaults to an empty array.
       def load_client_env
+        client_vars = %w( SENSU_CLIENT_NAME SENSU_CLIENT_ADDRESS SENSU_CLIENT_SUBSCRIPTIONS )
         @settings[:client][:name] = ENV["SENSU_CLIENT_NAME"] if ENV["SENSU_CLIENT_NAME"]
         @settings[:client][:address] = ENV["SENSU_CLIENT_ADDRESS"] if ENV["SENSU_CLIENT_ADDRESS"]
         @settings[:client][:subscriptions] = ENV.fetch("SENSU_CLIENT_SUBSCRIPTIONS", "").split(",")
-        warning("using sensu client environment variables", :client => @settings[:client])
+        if ENV.keys.any? {|k| client_vars.include?(k)}
+          warning("using sensu client environment variables", :client => @settings[:client])
+        end
         @indifferent_access = false
       end
 

--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -279,11 +279,10 @@ module Sensu
       #
       # The client subscriptions defaults to an empty array.
       def load_client_env
-        client_vars = %w( SENSU_CLIENT_NAME SENSU_CLIENT_ADDRESS SENSU_CLIENT_SUBSCRIPTIONS )
         @settings[:client][:name] = ENV["SENSU_CLIENT_NAME"] if ENV["SENSU_CLIENT_NAME"]
         @settings[:client][:address] = ENV["SENSU_CLIENT_ADDRESS"] if ENV["SENSU_CLIENT_ADDRESS"]
         @settings[:client][:subscriptions] = ENV.fetch("SENSU_CLIENT_SUBSCRIPTIONS", "").split(",")
-        if ENV.keys.any? {|k| client_vars.include?(k)}
+        if ENV.keys.any? {|k| k =~ /^SENSU_CLIENT/}
           warning("using sensu client environment variables", :client => @settings[:client])
         end
         @indifferent_access = false

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -25,6 +25,13 @@ describe "Sensu::Settings::Loader" do
     expect(failures.size).to eq(0)
   end
 
+  it "can load Sensu client settings with auto-detected defaults" do
+    @loader.load_env
+    expect(@loader.warnings.size).to eq(0)
+    expect(@loader.default_settings[:client][:name]).to be_kind_of(String)
+    expect(@loader.default_settings[:client][:address]).to be_kind_of(String)
+  end
+
   it "can load Sensu transport settings from the environment" do
     ENV["SENSU_TRANSPORT_NAME"] = "redis"
     @loader.load_env
@@ -53,15 +60,6 @@ describe "Sensu::Settings::Loader" do
     ENV["REDIS_URL"] = nil
   end
 
-  it "can load Sensu client settings with auto-detected defaults" do
-    @loader.load_env
-    expect(@loader.warnings.size).to eq(1)
-    warning = @loader.warnings.shift
-    client = warning[:client]
-    expect(client[:name]).to be_kind_of(String)
-    expect(client[:address]).to be_kind_of(String)
-  end
-
   it "can load Sensu client settings with defaults from the environment" do
     ENV["SENSU_CLIENT_NAME"] = "i-424242"
     @loader.load_env
@@ -86,6 +84,8 @@ describe "Sensu::Settings::Loader" do
     expect(client[:address]).to eq("127.0.0.1")
     expect(client[:subscriptions]).to eq(["foo", "bar", "baz"])
     ENV["SENSU_CLIENT_NAME"] = nil
+    ENV["SENSU_CLIENT_ADDRESS"] = nil
+    ENV["SENSU_CLIENT_SUBSCRIPTIONS"] = nil
   end
 
   it "can load Sensu API settings from the environment" do

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -53,6 +53,15 @@ describe "Sensu::Settings::Loader" do
     ENV["REDIS_URL"] = nil
   end
 
+  it "can load Sensu client settings with auto-detected defaults" do
+    @loader.load_env
+    expect(@loader.warnings.size).to eq(1)
+    warning = @loader.warnings.shift
+    client = warning[:client]
+    expect(client[:name]).to be_kind_of(String)
+    expect(client[:address]).to be_kind_of(String)
+  end
+
   it "can load Sensu client settings with defaults from the environment" do
     ENV["SENSU_CLIENT_NAME"] = "i-424242"
     @loader.load_env


### PR DESCRIPTION
With this change sensu-client processes will attempt to detect reasonable defaults for the client name and address attributes, using the hostname and the first detected non-loopback ipv4 address, respectively. These auto-detected defaults are overwritten by relevant environment variables or configuration loaded from disk.