### PR TITLE
add per-client subscriptions

### DIFF
--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -27,6 +27,7 @@ module Sensu
         if @loader.validate.empty?
           @loader.set_env!
         end
+        @loader.load_overrides!
         @loader
       rescue Loader::Error
         @loader

--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -8,6 +8,10 @@ module Sensu
     class Loader
       class Error < RuntimeError; end
 
+      # @!attribute [r] debug messages
+      #   @return [Array] loader debug messages
+      attr_reader :debug_msgs
+
       # @!attribute [r] warnings
       #   @return [Array] loader warnings.
       attr_reader :warnings
@@ -21,6 +25,7 @@ module Sensu
       attr_reader :loaded_files
 
       def initialize
+        @debug_msgs = []
         @warnings = []
         @errors = []
         @settings = default_settings
@@ -422,6 +427,17 @@ module Sensu
       # @return [Array] current warnings.
       def warning(message, data={})
         @warnings << {
+          :message => message
+        }.merge(data)
+      end
+
+      # Record a debug message.
+      #
+      # @param message [String] warning message.
+      # @param data [Hash] warning context.
+      # @return [Array] current warnings.
+      def debug(message, data={})
+        @debug_msgs << {
           :message => message
         }.merge(data)
       end

--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -118,7 +118,6 @@ module Sensu
         load_rabbitmq_env
         load_redis_env
         load_client_env
-        load_client_overrides
         load_api_env
       end
 
@@ -172,6 +171,24 @@ module Sensu
         else
           load_error("insufficient permissions for loading", :directory => directory)
         end
+      end
+
+      # Load Sensu client settings overrides. This method adds any overrides to
+      # the client definition. Overrides include:
+      #
+      # * Ensuring client subscriptions include a single subscription based on the
+      # client name, e.g "client:i-424242".
+      def load_client_overrides
+        @settings[:client][:subscriptions] ||= []
+        @settings[:client][:subscriptions] << "client:#{@settings[:client][:name]}"
+        @settings[:client][:subscriptions].uniq!
+        debug("applied sensu client overrides", :client => @settings[:client])
+      end
+
+      # Load overrides, i.e. settings which should always be present.
+      # Examples include client settings overrides which ensure a per-client subscription.
+      def load_overrides!
+        load_client_overrides
       end
 
       # Set Sensu settings related environment variables. This method
@@ -290,16 +307,6 @@ module Sensu
           warning("using sensu client environment variables", :client => @settings[:client])
         end
         @indifferent_access = false
-      end
-
-      # Load Sensu client settings overrides. This method adds any overrides to
-      # the client definition. Overrides include:
-      #
-      # * Ensuring client subscriptions include a single subscription based on the
-      # client name, e.g "client:i-424242".
-      def load_client_overrides
-        @settings[:client][:subscriptions] << "client:#{@settings[:client][:name]}"
-        @settings[:client][:subscriptions].uniq!
       end
 
       # Load Sensu API settings from the environment. This method sets

--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -8,10 +8,6 @@ module Sensu
     class Loader
       class Error < RuntimeError; end
 
-      # @!attribute [r] debug messages
-      #   @return [Array] loader debug messages
-      attr_reader :debug_msgs
-
       # @!attribute [r] warnings
       #   @return [Array] loader warnings.
       attr_reader :warnings
@@ -25,7 +21,6 @@ module Sensu
       attr_reader :loaded_files
 
       def initialize
-        @debug_msgs = []
         @warnings = []
         @errors = []
         @settings = default_settings
@@ -182,7 +177,7 @@ module Sensu
         @settings[:client][:subscriptions] ||= []
         @settings[:client][:subscriptions] << "client:#{@settings[:client][:name]}"
         @settings[:client][:subscriptions].uniq!
-        debug("applied sensu client overrides", :client => @settings[:client])
+        warning("applied sensu client overrides", :client => @settings[:client])
       end
 
       # Load overrides, i.e. settings which should always be present.
@@ -434,17 +429,6 @@ module Sensu
       # @return [Array] current warnings.
       def warning(message, data={})
         @warnings << {
-          :message => message
-        }.merge(data)
-      end
-
-      # Record a debug message.
-      #
-      # @param message [String] warning message.
-      # @param data [Hash] warning context.
-      # @return [Array] current warnings.
-      def debug(message, data={})
-        @debug_msgs << {
           :message => message
         }.merge(data)
       end

--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -277,11 +277,14 @@ module Sensu
       # `SENSU_CLIENT_NAME`, `SENSU_CLIENT_ADDRESS`, and
       # `SENSU_CLIENT_SUBSCRIPTIONS`.
       #
-      # The client subscriptions defaults to an empty array.
+      # The client subscriptions defaults to a single subscription based on the
+      # client name, e.g "client:i-424242".
       def load_client_env
         @settings[:client][:name] = ENV["SENSU_CLIENT_NAME"] if ENV["SENSU_CLIENT_NAME"]
         @settings[:client][:address] = ENV["SENSU_CLIENT_ADDRESS"] if ENV["SENSU_CLIENT_ADDRESS"]
         @settings[:client][:subscriptions] = ENV.fetch("SENSU_CLIENT_SUBSCRIPTIONS", "").split(",")
+        @settings[:client][:subscriptions] << "client:#{@settings[:client][:name]}"
+        @settings[:client][:subscriptions].uniq!
         if ENV.keys.any? {|k| k =~ /^SENSU_CLIENT/}
           warning("using sensu client environment variables", :client => @settings[:client])
         end

--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -113,6 +113,7 @@ module Sensu
         load_rabbitmq_env
         load_redis_env
         load_client_env
+        load_client_overrides
         load_api_env
       end
 
@@ -276,19 +277,24 @@ module Sensu
       # loads client settings from several variables:
       # `SENSU_CLIENT_NAME`, `SENSU_CLIENT_ADDRESS`, and
       # `SENSU_CLIENT_SUBSCRIPTIONS`.
-      #
-      # The client subscriptions defaults to a single subscription based on the
-      # client name, e.g "client:i-424242".
       def load_client_env
         @settings[:client][:name] = ENV["SENSU_CLIENT_NAME"] if ENV["SENSU_CLIENT_NAME"]
         @settings[:client][:address] = ENV["SENSU_CLIENT_ADDRESS"] if ENV["SENSU_CLIENT_ADDRESS"]
         @settings[:client][:subscriptions] = ENV.fetch("SENSU_CLIENT_SUBSCRIPTIONS", "").split(",")
-        @settings[:client][:subscriptions] << "client:#{@settings[:client][:name]}"
-        @settings[:client][:subscriptions].uniq!
         if ENV.keys.any? {|k| k =~ /^SENSU_CLIENT/}
           warning("using sensu client environment variables", :client => @settings[:client])
         end
         @indifferent_access = false
+      end
+
+      # Load Sensu client settings overrides. This method adds any overrides to
+      # the client definition. Overrides include:
+      #
+      # * Ensuring client subscriptions include a single subscription based on the
+      # client name, e.g "client:i-424242".
+      def load_client_overrides
+        @settings[:client][:subscriptions] << "client:#{@settings[:client][:name]}"
+        @settings[:client][:subscriptions].uniq!
       end
 
       # Load Sensu API settings from the environment. This method sets

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -226,9 +226,9 @@ describe "Sensu::Settings::Loader" do
   it "can load settings overrides" do
     @loader.load_file(@config_file)
     @loader.load_overrides!
-    expect(@loader.warnings.size).to eq(1)
-    debug = @loader.debug_msgs.shift
-    client = debug[:client]
+    expect(@loader.warnings.size).to eq(2)
+    warning = @loader.warnings[1]
+    client = warning[:client]
     expect(client[:subscriptions]).to include("client:i-424242")
   end
 end

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -68,7 +68,7 @@ describe "Sensu::Settings::Loader" do
     client = warning[:client]
     expect(client[:name]).to eq("i-424242")
     expect(client[:address]).to be_kind_of(String)
-    expect(client[:subscriptions]).to eq(["client:i-424242"])
+    expect(client[:subscriptions]).to eq([])
     ENV["SENSU_CLIENT_NAME"] = nil
   end
 
@@ -82,21 +82,9 @@ describe "Sensu::Settings::Loader" do
     client = warning[:client]
     expect(client[:name]).to eq("i-424242")
     expect(client[:address]).to eq("127.0.0.1")
-    expect(client[:subscriptions]).to eq(["foo", "bar", "baz", "client:i-424242"])
+    expect(client[:subscriptions]).to eq(["foo", "bar", "baz"])
     ENV["SENSU_CLIENT_NAME"] = nil
     ENV["SENSU_CLIENT_ADDRESS"] = nil
-    ENV["SENSU_CLIENT_SUBSCRIPTIONS"] = nil
-  end
-
-  it "can load Sensu client subscriptions from the environment without duplication" do
-    ENV["SENSU_CLIENT_NAME"] = "i-424242"
-    ENV["SENSU_CLIENT_SUBSCRIPTIONS"] = "client:i-424242"
-    @loader.load_env
-    expect(@loader.warnings.size).to eq(1)
-    warning = @loader.warnings.shift
-    client = warning[:client]
-    expect(client[:subscriptions]).to eq(["client:i-424242"])
-    ENV["SENSU_CLIENT_NAME"] = nil
     ENV["SENSU_CLIENT_SUBSCRIPTIONS"] = nil
   end
 
@@ -233,5 +221,14 @@ describe "Sensu::Settings::Loader" do
       handler[:name] == "default"
     end
     expect(handler[:type]).to eq("set")
+  end
+
+  it "can load settings overrides" do
+    @loader.load_file(@config_file)
+    @loader.load_overrides!
+    expect(@loader.warnings.size).to eq(1)
+    debug = @loader.debug_msgs.shift
+    client = debug[:client]
+    expect(client[:subscriptions]).to include("client:i-424242")
   end
 end

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -68,7 +68,7 @@ describe "Sensu::Settings::Loader" do
     client = warning[:client]
     expect(client[:name]).to eq("i-424242")
     expect(client[:address]).to be_kind_of(String)
-    expect(client[:subscriptions]).to eq([])
+    expect(client[:subscriptions]).to eq(["client:i-424242"])
     ENV["SENSU_CLIENT_NAME"] = nil
   end
 
@@ -82,9 +82,21 @@ describe "Sensu::Settings::Loader" do
     client = warning[:client]
     expect(client[:name]).to eq("i-424242")
     expect(client[:address]).to eq("127.0.0.1")
-    expect(client[:subscriptions]).to eq(["foo", "bar", "baz"])
+    expect(client[:subscriptions]).to eq(["foo", "bar", "baz", "client:i-424242"])
     ENV["SENSU_CLIENT_NAME"] = nil
     ENV["SENSU_CLIENT_ADDRESS"] = nil
+    ENV["SENSU_CLIENT_SUBSCRIPTIONS"] = nil
+  end
+
+  it "can load Sensu client subscriptions from the environment without duplication" do
+    ENV["SENSU_CLIENT_NAME"] = "i-424242"
+    ENV["SENSU_CLIENT_SUBSCRIPTIONS"] = "client:i-424242"
+    @loader.load_env
+    expect(@loader.warnings.size).to eq(1)
+    warning = @loader.warnings.shift
+    client = warning[:client]
+    expect(client[:subscriptions]).to eq(["client:i-424242"])
+    ENV["SENSU_CLIENT_NAME"] = nil
     ENV["SENSU_CLIENT_SUBSCRIPTIONS"] = nil
   end
 

--- a/spec/settings_spec.rb
+++ b/spec/settings_spec.rb
@@ -60,8 +60,8 @@ describe "Sensu::Settings" do
   it "can handle a nonexistent config.json" do
     settings = Sensu::Settings.load(:config_file => "/tmp/bananaphone")
     expect(settings.errors.length).to eq(0)
-    expect(settings.warnings.length).to eq(2)
-    warning = settings.warnings.last
+    expect(settings.warnings.length).to eq(3)
+    warning = settings.warnings[1]
     expect(warning[:message]).to include("ignoring config file")
   end
 end


### PR DESCRIPTION
This change set implements the per-client subscription feature as described in
https://github.com/sensu/sensu/issues/1327:

> The Sensu client should automatically create a subscription called
>  `clint:client-name` (e.g. `client:i-424242`) for every client. This will allow
> for other features in Sensu to target specific clients or groups of clients
> using subscriptions.

This feature is intended to support per-client silencing via the new silence API
described in https://github.com/sensu/sensu/issues/1328