### PR TITLE
Server fails without client config redux

### DIFF
--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -310,7 +310,7 @@ module Sensu
       def load_client_env
         @settings[:client][:name] = ENV["SENSU_CLIENT_NAME"] if ENV["SENSU_CLIENT_NAME"]
         @settings[:client][:address] = ENV["SENSU_CLIENT_ADDRESS"] if ENV["SENSU_CLIENT_ADDRESS"]
-        @settings[:client][:subscriptions] = ENV.fetch("SENSU_CLIENT_SUBSCRIPTIONS", "").split(",")
+        @settings[:client][:subscriptions] = ENV["SENSU_CLIENT_SUBSCRIPTIONS"].split(",") if ENV["SENSU_CLIENT_SUBSCRIPTIONS"]
         if ENV.keys.any? {|k| k =~ /^SENSU_CLIENT/}
           warning("using sensu client environment variables", :client => @settings[:client])
         end

--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -51,6 +51,7 @@ module Sensu
       # @return [Hash] settings.
       def default_settings
         default = {
+          :client => {},
           :sensu => {
             :spawn => {
               :limit => 12
@@ -174,7 +175,6 @@ module Sensu
       # * Ensuring client subscriptions include a single subscription based on the
       # client name, e.g "client:i-424242".
       def load_client_overrides
-        @settings[:client] ||= {}
         @settings[:client][:subscriptions] ||= []
         @settings[:client][:subscriptions] << "client:#{@settings[:client][:name]}"
         @settings[:client][:subscriptions].uniq!

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -77,7 +77,7 @@ describe "Sensu::Settings::Loader" do
     client = warning[:client]
     expect(client[:name]).to eq("i-424242")
     expect(client[:address]).to be_kind_of(String)
-    expect(client[:subscriptions]).to eq([])
+    expect(client[:subscriptions]).to eq(nil)
     ENV["SENSU_CLIENT_NAME"] = nil
   end
 


### PR DESCRIPTION
* Ensure `client` defaults to empty hash
* Ensure load_client_env doesn't set client.subscriptions to empty array when `ENV['SENSU_CLIENT_SUBSCRIPTIONS']` is unset

Closes sensu/sensu#1444
Relates to sensu/sensu#1437
Relates to #44