### PR TITLE
[settings] load automatic override settings prior to validation

### DIFF
--- a/lib/sensu/settings.rb
+++ b/lib/sensu/settings.rb
@@ -5,6 +5,11 @@ module Sensu
     class << self
       # Load Sensu settings.
       #
+      # Settings are loaded in following order, prior to validation:
+      # 1. Environment Variables
+      # 2. JSON files on disk
+      # 3. Automaticly detected overrides (e.g. hostname, IP address)
+      #
       # @param [Hash] options
       # @option options [String] :config_file to load.
       # @option options [String] :config_dir to load.
@@ -24,10 +29,10 @@ module Sensu
             @loader.load_directory(directory)
           end
         end
+        @loader.load_overrides!
         if @loader.validate.empty?
           @loader.set_env!
         end
-        @loader.load_overrides!
         @loader
       rescue Loader::Error
         @loader


### PR DESCRIPTION
This changes the load order so that automatic override settings are loaded prior to
settings validation, avoiding spurious errors if client subscriptions are not otherwise 
defined.

Closes #47 