### PR TITLE
[loader] treat empty json files as an empty hash

### DIFF
--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -127,7 +127,7 @@ module Sensu
           begin
             warning("loading config file", :file => file)
             contents = read_config_file(file)
-            config = Sensu::JSON.load(contents)
+            config = contents.empty? ? {} : Sensu::JSON.load(contents)
             merged = deep_merge(@settings, config)
             unless @loaded_files.empty?
               changes = deep_diff(@settings, merged)

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -114,6 +114,13 @@ describe "Sensu::Settings::Loader" do
     expect(@loader["api"]["port"]).to eq(4567)
   end
 
+  it "can load an empty file" do
+    empty_file = File.join(@assets_dir, "empty.json")
+    @loader.load_file(empty_file)
+    warning = @loader.warnings.first
+    expect(warning[:file]).to eq(File.expand_path(empty_file))
+  end
+
   it "can load settings from a file and validate them" do
     @loader.load_file(@config_file)
     failures = @loader.validate


### PR DESCRIPTION
As described in #49, attempting to load an empty file causes an exception when
we subsequently attempt to parse an empty string as JSON and treat the resulting
nil as a hash.

This change uses a terinary operation to return an empty hash when the loaded
file content is an empty string, otherwise parsing the file content as JSON.

Closes #49
Closes sensu/sensu-build#173
Closes sensu/sensu-enterprise#163