### PR TITLE
Validate sensu keepalives, default keepalives thresholds

### DIFF
--- a/lib/sensu/settings/loader.rb
+++ b/lib/sensu/settings/loader.rb
@@ -56,6 +56,12 @@ module Sensu
           :sensu => {
             :spawn => {
               :limit => 12
+            },
+            :keepalives => {
+              :thresholds => {
+                :warning => 120,
+                :critical => 180
+              }
             }
           },
           :transport => {

--- a/lib/sensu/settings/validators/sensu.rb
+++ b/lib/sensu/settings/validators/sensu.rb
@@ -20,13 +20,59 @@ module Sensu
           end
         end
 
+        # Validate Sensu keepalives thresholds.
+        # Validates: warning, critical
+        #
+        # @param sensu [Hash] sensu definition.
+        def validate_sensu_keepalives_thresholds(sensu)
+          thresholds = sensu[:keepalives][:thresholds]
+          must_be_a_hash_if_set(thresholds) ||
+            invalid(sensu, "sensu keepalives thresholds must be a hash")
+          if is_a_hash?(thresholds)
+            must_be_an_integer_if_set(thresholds[:warning]) ||
+              invalid(sensu, "sensu keepalives warning threshold must be an integer")
+            must_be_an_integer_if_set(thresholds[:critical]) ||
+              invalid(sensu, "sensu keepalives critical threshold must be an integer")
+          end
+        end
+
+        # Validate Sensu keepalives handlers.
+        # Validates: handler, handlers
+        #
+        # @param sensu [Hash] sensu definition.
+        def validate_sensu_keepalives_handlers(sensu)
+          must_be_a_string_if_set(sensu[:keepalives][:handler]) ||
+            invalid(sensu, "sensu keepalives handler must be a string")
+          must_be_an_array_if_set(sensu[:keepalives][:handlers]) ||
+            invalid(sensu, "sensu keepalives handlers must be an array")
+          if is_an_array?(sensu[:keepalives][:handlers])
+            items_must_be_strings(sensu[:keepalives][:handlers]) ||
+              invalid(sensu, "sensu keepalives handlers must each be a string")
+          end
+        end
+
+
+        # Validate Sensu keepalives.
+        # Validates: thresholds (warning, critical), handler, handlers
+        #
+        # @param sensu [Hash] sensu definition.
+        def validate_sensu_keepalives(sensu)
+          if is_a_hash?(sensu[:keepalives])
+            validate_sensu_keepalives_thresholds(sensu)
+            validate_sensu_keepalives_handlers(sensu)
+          else
+            invalid(sensu, "sensu keepalives must be a hash")
+          end
+        end
+
         # Validate a Sensu definition.
-        # Validates: spawn
+        # Validates: spawn, keepalives
         #
         # @param sensu [Hash] sensu definition.
         def validate_sensu(sensu)
           if is_a_hash?(sensu)
             validate_sensu_spawn(sensu)
+            validate_sensu_keepalives(sensu)
           else
             invalid(sensu, "sensu must be a hash")
           end

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -34,17 +34,53 @@ describe "Sensu::Settings::Validator" do
     expect(@validator.reset).to eq(1)
     sensu = {}
     @validator.validate_sensu(sensu)
-    expect(@validator.reset).to eq(1)
+    expect(@validator.reset).to eq(2)
     sensu[:spawn] = 1
     @validator.validate_sensu(sensu)
-    expect(@validator.reset).to eq(1)
+    expect(@validator.reset).to eq(2)
     sensu[:spawn] = {}
     @validator.validate_sensu(sensu)
-    expect(@validator.reset).to eq(1)
+    expect(@validator.reset).to eq(2)
     sensu[:spawn][:limit] = "1"
     @validator.validate_sensu(sensu)
-    expect(@validator.reset).to eq(1)
+    expect(@validator.reset).to eq(2)
     sensu[:spawn][:limit] = 20
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:keepalives] = {}
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(0)
+    sensu[:keepalives][:thresholds] = true
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:keepalives][:thresholds] = {}
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(0)
+    sensu[:keepalives][:thresholds][:warning] = "60"
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:keepalives][:thresholds][:warning] = 60
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(0)
+    sensu[:keepalives][:thresholds][:critical] = "80"
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:keepalives][:thresholds][:critical] = 80
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(0)
+    sensu[:keepalives][:handler] = 1
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:keepalives][:handler] = "foo"
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(0)
+    sensu[:keepalives][:handlers] = 1
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:keepalives][:handlers] = [1]
+    @validator.validate_sensu(sensu)
+    expect(@validator.reset).to eq(1)
+    sensu[:keepalives][:handlers] = ["foo"]
     @validator.validate_sensu(sensu)
     expect(@validator.reset).to eq(0)
   end
@@ -58,8 +94,11 @@ describe "Sensu::Settings::Validator" do
       }
     }
     @validator.run(settings)
-    expect(@validator.reset).to eq(7)
+    expect(@validator.reset).to eq(8)
     settings[:sensu][:spawn][:limit] = 20
+    @validator.run(settings)
+    expect(@validator.reset).to eq(7)
+    settings[:sensu][:keepalives] = {}
     @validator.run(settings)
     expect(@validator.reset).to eq(6)
   end


### PR DESCRIPTION
Need to validate and default Sensu keepalives attributes (`{"sensu": {"spawn": {}, "keepalives": {}}}`). This is for https://github.com/sensu/sensu/pull/1761.