### PR TITLE
Validate setting category object types

### DIFF
--- a/lib/sensu/settings/validator.rb
+++ b/lib/sensu/settings/validator.rb
@@ -47,7 +47,8 @@ module Sensu
       private
 
       # Validate setting categories: checks, filters, mutators, and
-      # handlers.
+      # handlers. This method also validates each object type,
+      # ensuring that they are hashes.
       #
       # @param settings [Hash] sensu settings to validate.
       def validate_categories(settings)
@@ -55,7 +56,12 @@ module Sensu
           if is_a_hash?(settings[category])
             validate_method = ("validate_" + category.to_s.chop).to_sym
             settings[category].each do |name, details|
-              send(validate_method, details.merge(:name => name.to_s))
+              if details.is_a?(Hash)
+                send(validate_method, details.merge(:name => name.to_s))
+              else
+                object_type = category[0..-2]
+                invalid(details, "#{object_type} must be a hash")
+              end
             end
           else
             invalid(settings[category], "#{category} must be a hash")

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -25,6 +25,16 @@ describe "Sensu::Settings::Validator" do
     expect(reasons.size).to eq(7)
   end
 
+  it "can run, validating setting category object types" do
+    failures = @validator.run({
+      :checks => {
+        :foo => ["invalid"]
+      }
+    })
+    expect(failures).to be_kind_of(Array)
+    expect(failures).to include({:object => ["invalid"], :message => "check must be a hash"})
+  end
+
   it "can validate a sensu definition" do
     sensu = nil
     @validator.validate_sensu(sensu)


### PR DESCRIPTION
This pull request gets Sensu validating setting category (i.e. checks) object types, ensuring that they are hashes.

Example validation message: "check must be a hash"

Reported by subbene on the community slack:

```
/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-settings-10.0.0/lib/sensu/settings/loader.rb:252:in `block in setting_category': undefined method `merge' for ["subscription"]:Array (NoMethodError)
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-settings-10.0.0/lib/sensu/settings/loader.rb:251:in `each'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-settings-10.0.0/lib/sensu/settings/loader.rb:251:in `map'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-settings-10.0.0/lib/sensu/settings/loader.rb:251:in `setting_category'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-settings-10.0.0/lib/sensu/settings/loader.rb:80:in `block (2 levels) in create_category_methods'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-0.29.0/lib/sensu/server/process.rb:920:in `setup_check_request_publisher'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-0.29.0/lib/sensu/server/process.rb:1137:in `block in setup_task'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-redis-2.1.1/lib/sensu/redis/client.rb:334:in `dispatch_response'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-redis-2.1.1/lib/sensu/redis/client.rb:350:in `parse_response_line'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-redis-2.1.1/lib/sensu/redis/client.rb:384:in `receive_data'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/eventmachine-1.2.2/lib/eventmachine.rb:194:in `run_machine'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/eventmachine-1.2.2/lib/eventmachine.rb:194:in `run'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-0.29.0/lib/sensu/server/process.rb:33:in `run'
        from /opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-0.29.0/exe/sensu-server:10:in `<top (required)>'
        from /opt/sensu/bin/sensu-server:22:in `load'
        from /opt/sensu/bin/sensu-server:22:in `<main>
```

The invalid configuration:

```
{
    "checks": {
        "keepalive": {
            "command": ":keepalive",
            "thresholds": {
                "warning": 40,
                 "critical": 60
            }
        },
        "subscribers": [
            "subscription"
        ]
    }
}
```

"subscribers" was configured in the incorrect scope and sensu attempted to merge an array with a hash.