### PR TITLE
make it clear that each element must be a non empty string

### DIFF
--- a/lib/sensu/settings/validators/client.rb
+++ b/lib/sensu/settings/validators/client.rb
@@ -9,7 +9,7 @@ module Sensu
         def validate_client_subscriptions(client)
           if is_an_array?(client[:subscriptions])
             items_must_be_strings(client[:subscriptions]) ||
-              invalid(client, "client subscriptions must each be a string")
+              invalid(client, "client subscriptions must each be a non empty string")
           else
             invalid(client, "client subscriptions must be an array")
           end


### PR DESCRIPTION
The message indicates that it will accept any string but after inspecting the code and the clients subscriptions it does not support a subscription with an ampty string.

Code: https://github.com/sensu/sensu-settings/blob/v10.14.0/lib/sensu/settings/rules.rb#L113-L123

Example Error:
```
Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '2'
    ---- Begin output of /etc/init.d/sensu-client restart ----
    STDOUT: configuration is invalid
    {
      "errors":[
        {
          "object":{
            "name":"dokken",
            "address":"172.18.0.13",
            "subscriptions":[
              "",
              "base",
              "kitchen",
              "rails_app_testing",
              "rails_app_testing_kitchen",
              "roundrobin:rails_app_testing_kitchen",
              "client:dokken"
            ],
            "keepalive":{
              "thresholds":{
                "warning":200,
                "critical":240
              },
              "handlers":[
                "default"
              ],
              "refresh":1800
            },
            "redact":[
              "password",
              "passwd",
              "pass",
              "api_key",
              "api_token",
              "access_key",
              "secret_key",
              "private_key",
              "secret"
            ],
            "environment":"kitchen"
          },
          "message":"client subscriptions must each be a string"
        }
      ]
    }
    STDERR:
    ---- End output of /etc/init.d/sensu-client restart ----
    Ran /etc/init.d/sensu-client restart returned 2
```

Signed-off-by: Ben Abrams <me@benabrams.it>